### PR TITLE
Send out deprecation warning for ArtifactsWrappers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.3'
-          - '1.4'
           - '1.5'
           - '1.6.0'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArtifactWrappers"
 uuid = "a14bc488-3040-4b00-9dc1-f6467924858a"
 authors = ["Climate Modeling Alliance"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"

--- a/src/ArtifactWrappers.jl
+++ b/src/ArtifactWrappers.jl
@@ -76,6 +76,11 @@ function ArtifactWrapper(
     artifact_files;
     lazy_download = true,
 )
+    Base.depwarn(
+        "ArtifactWrapper is deprecated. Use ClimaArtifacts instead.",
+        :ArtifactWrapper,
+        force = true,
+    )
     artifact_toml = joinpath(artifact_dir, "Artifacts.toml")
     return ArtifactWrapper(
         artifact_dir,
@@ -99,6 +104,11 @@ dataset_path = get_data_folder(dataset)
 ```
 """
 function get_data_folder(art_wrap::ArtifactWrapper)
+    Base.depwarn(
+        "ArtifactWrapper is deprecated. Use ClimaArtifacts instead.",
+        :get_data_folder,
+        force = true,
+    )
     if !art_wrap.lazy_download
         # When running multiple jobs, create_artifact
         # has a race condition when creating/moving


### PR DESCRIPTION
Send out deprecation warning for ArtifactsWrappers. Let's use Julia artifacts instead.